### PR TITLE
Fix reference to B2, both text and links.

### DIFF
--- a/getting_started/detail/build-from-source-head.rst
+++ b/getting_started/detail/build-from-source-head.rst
@@ -2,21 +2,21 @@
 .. Software License, Version 1.0. (See accompanying
 .. file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-Install Boost.Build
-...................
+Install B2
+..........
 
-Boost.Build_ is a text-based system for developing, testing, and
+B2_ is a text-based system for developing, testing, and
 installing software. First, you'll need to build and
 install it. To do this:
 
 1. Go to the directory ``tools``\ |/|\ ``build``\ |/|.
 2. Run |bootstrap|
 3. Run ``b2 install --prefix=``\ *PREFIX* where *PREFIX* is
-   the directory where you want Boost.Build to be installed
+   the directory where you want B2 to be installed
 4. Add *PREFIX*\ |/|\ ``bin`` to your PATH environment variable.
 
-.. _Boost.Build: ../../tools/build/index.html
-.. _Boost.Build documentation: Boost.Build_
+.. _B2: ../../tools/build/doc/html/index.html
+.. _B2 documentation: B2_
 
 .. _toolset:
 .. _toolset-name:
@@ -26,15 +26,15 @@ Identify Your Toolset
 
 First, find the toolset corresponding to your compiler in the
 following table (an up-to-date list is always available `in the
-Boost.Build documentation`__).
+B2 documentation`__).
 
-__ https://boostorg.github.io/build/manual/develop/index.html#bbv2.reference.tools
+__ ../../tools/build/doc/html/index.html#bbv2.reference.tools
 
 .. Note:: If you previously chose a toolset for the purposes of
   `building b2`_, you should assume it won't work and instead
   choose newly from the table below.
 
-.. _building b2: ../../doc/html/bbv2/installation.html
+.. _building b2: ../../tools/build/doc/html/index.html#bbv2.installation
 
 +-----------+--------------------+------------------------------------------------------------+
 |Toolset    |Vendor              |Notes                                                       |
@@ -73,7 +73,7 @@ __ https://boostorg.github.io/build/manual/develop/index.html#bbv2.reference.too
 |``vacpp``  |IBM                 |The VisualAge C++ compiler.                                 |
 +-----------+--------------------+------------------------------------------------------------+
 
-__ Boost.Build_
+__ B2_
 
 If you have multiple versions of a particular compiler installed,
 you can append the version number to the toolset name, preceded by
@@ -87,10 +87,10 @@ a hyphen, e.g. ``intel-9.0`` or
 Select a Build Directory
 ........................
 
-Boost.Build_ will place all intermediate files it generates while
+B2_ will place all intermediate files it generates while
 building into the **build directory**.  If your Boost root
 directory is writable, this step isn't strictly necessary: by
-default Boost.Build will create a ``bin.v2/`` subdirectory for that
+default B2 will create a ``bin.v2/`` subdirectory for that
 purpose in your current working directory.
 
 Invoke ``b2``
@@ -107,7 +107,7 @@ invoke ``b2`` as follows:
   b2 **--build-dir=**\ |build-directory|_ **toolset=**\ |toolset-name|_ |build-type-complete| stage
 
 For a complete description of these and other invocation options,
-please see the `Boost.Build documentation`__.
+please see the `B2 documentation`__.
 
-__ http://www.boost.org/build/doc/html/bbv2/overview/invocation.html
+__ ../../tools/build/doc/html/index.html#bbv2.overview.invocation
 

--- a/getting_started/detail/build-from-source-tail.rst
+++ b/getting_started/detail/build-from-source-tail.rst
@@ -24,7 +24,7 @@ be interested in:
 * choosing a specific build variant by adding ``release`` or
   ``debug`` to the command line.
 
-.. Note:: Boost.Build can produce a great deal of output, which can
+.. Note:: B2 can produce a great deal of output, which can
      make it easy to miss problems.  If you want to make sure
      everything is went well, you might redirect the output into a
      file by appending “``>build.log 2>&1``” to your command line.
@@ -68,6 +68,6 @@ If it seems like the build system can't find your compiler and/or
 linker, consider setting up a ``user-config.jam`` file as described
 `here`__.  If that isn't your problem or the ``user-config.jam`` file
 doesn't work for you, please address questions about configuring Boost
-for your compiler to the `Boost.Build mailing list`_.
+for your compiler to the `Boost Users' mailing list`_.
 
-__ http://www.boost.org/build/doc/html/bbv2/overview/configuration.html
+__ ../../tools/build/doc/html/index.html#bbv2.overview.configuration

--- a/getting_started/detail/conclusion.rst
+++ b/getting_started/detail/conclusion.rst
@@ -14,9 +14,8 @@ If you can't find what you need, or there's anything we can do to
 make this document clearer, please post it to the `Boost Users'
 mailing list`_.
 
-* `Boost.Build reference manual`_
+* `B2 reference manual`_
 * `Boost Users' mailing list`_
-* `Boost.Build mailing list`_
 * `Index of all Boost library documentation`_
 
 .. _Index of all Boost library documentation: ../../libs/index.html
@@ -29,7 +28,6 @@ mailing list`_.
 
      -- the Boost Developers
 
-.. _Boost.Build reference manual: ../../tools/build/index.html
+.. _B2 reference manual: ../../tools/build/doc/html/index.html
 .. _Boost Users' mailing list: http://www.boost.org/more/mailing_lists.htm#users
-.. _Boost.Build mailing list: http://www.boost.org/more/mailing_lists.htm#jamboost
 

--- a/getting_started/detail/distro.rst
+++ b/getting_started/detail/distro.rst
@@ -20,7 +20,7 @@ This is a sketch of the resulting directory structure:
       **array**\ |//|
                       *…more libraries…*
     **status**\ |//| .........................\ *Boost-wide test suite*
-    **tools**\ |//| ...........\ *Utilities, e.g. Boost.Build, quickbook, bcp*
+    **tools**\ |//| ...........\ *Utilities, e.g. B2, quickbook, bcp*
     **more**\ |//| ..........................\ *Policy documents, etc.*
     **doc**\ |//| ...............\ *A subset of all Boost library docs*
 

--- a/getting_started/detail/library-naming.rst
+++ b/getting_started/detail/library-naming.rst
@@ -34,7 +34,7 @@ following elements:
    feature, a single letter is added to the tag:
 
      +-----+------------------------------------------------------------------------------+---------------------+
-     |Key  |Use this library when:                                                        |Boost.Build option   |
+     |Key  |Use this library when:                                                        |B2 option            |
      +=====+==============================================================================+=====================+
      |``s``|linking statically to the C++ standard library and compiler runtime support   |runtime-link=static  |
      |     |libraries.                                                                    |                     |
@@ -59,7 +59,7 @@ following elements:
   *Architecture and address model tag*: in the first letter, encodes the architecture as follows:
 
      +-----+------------------+---------------------+
-     |Key  |Architecture      |Boost.Build option   |
+     |Key  |Architecture      |B2 option            |
      +=====+==================+=====================+
      |``x``|x86-32, x86-64    |architecture=x86     |
      +-----+------------------+---------------------+
@@ -77,7 +77,7 @@ following elements:
   The two digits following the letter encode the address model as follows:
 
      +------+------------------+---------------------+
-     |Key   |Address model     |Boost.Build option   |
+     |Key   |Address model     |B2 option            |
      +======+==================+=====================+
      |``32``|32 bit            |address-model=32     |
      +------+------------------+---------------------+
@@ -100,7 +100,7 @@ following elements:
   a symbolic link to the library file, named without the trailing
   version number, will also be created.
 
-.. .. _Boost.Build toolset names: toolset-name_
+.. .. _B2 toolset names: toolset-name_
 
 __ ../../libs/python/doc/html/building/python_debugging_builds.html
 

--- a/getting_started/unix-variants.html
+++ b/getting_started/unix-variants.html
@@ -40,7 +40,7 @@
 <li><a class="reference internal" href="#prepare-to-use-a-boost-library-binary" id="id25">5&nbsp;&nbsp;&nbsp;Prepare to Use a Boost Library Binary</a><ul class="auto-toc">
 <li><a class="reference internal" href="#easy-build-and-install" id="id26">5.1&nbsp;&nbsp;&nbsp;Easy Build and Install</a></li>
 <li><a class="reference internal" href="#or-build-custom-binaries" id="id27">5.2&nbsp;&nbsp;&nbsp;Or, Build Custom Binaries</a><ul class="auto-toc">
-<li><a class="reference internal" href="#install-boost-build" id="id28">5.2.1&nbsp;&nbsp;&nbsp;Install Boost.Build</a></li>
+<li><a class="reference internal" href="#install-b2" id="id28">5.2.1&nbsp;&nbsp;&nbsp;Install B2</a></li>
 <li><a class="reference internal" href="#identify-your-toolset" id="id29">5.2.2&nbsp;&nbsp;&nbsp;Identify Your Toolset</a></li>
 <li><a class="reference internal" href="#select-a-build-directory" id="id30">5.2.3&nbsp;&nbsp;&nbsp;Select a Build Directory</a></li>
 <li><a class="reference internal" href="#invoke-b2" id="id31">5.2.4&nbsp;&nbsp;&nbsp;Invoke <tt class="docutils literal">b2</tt></a></li>
@@ -102,7 +102,7 @@ from <a class="reference external" href="http://www.boost.org/users/history/vers
      <strong>array</strong><strong>/</strong>
                      <em>…more libraries…</em>
    <strong>status</strong><strong>/</strong> .........................<em>Boost-wide test suite</em>
-   <strong>tools</strong><strong>/</strong> ...........<em>Utilities, e.g. Boost.Build, quickbook, bcp</em>
+   <strong>tools</strong><strong>/</strong> ...........<em>Utilities, e.g. B2, quickbook, bcp</em>
    <strong>more</strong><strong>/</strong> ..........................<em>Policy documents, etc.</em>
    <strong>doc</strong><strong>/</strong> ...............<em>A subset of all Boost library docs</em>
 </pre>
@@ -301,35 +301,35 @@ path in place of the Boost root directory.</p>
 <div class="section" id="or-build-custom-binaries">
 <h2><a class="toc-backref" href="#id27">5.2&nbsp;&nbsp;&nbsp;Or, Build Custom Binaries</a></h2>
 <p>If you're using a compiler other than your system's default, you'll
-need to use <a class="reference external" href="../../tools/build/index.html">Boost.Build</a> to create binaries.</p>
+need to use <a class="reference external" href="../../tools/build/doc/html/index.html">B2</a> to create binaries.</p>
 <p>You'll also
 use this method if you need a nonstandard build variant (see the
-<a class="reference external" href="../../tools/build/index.html">Boost.Build documentation</a> for more details).</p>
+<a class="reference external" href="../../tools/build/doc/html/index.html">B2 documentation</a> for more details).</p>
 <!-- Copyright David Abrahams 2006. Distributed under the Boost -->
 <!-- Software License, Version 1.0. (See accompanying -->
 <!-- file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt) -->
-<div class="section" id="install-boost-build">
-<h3><a class="toc-backref" href="#id28">5.2.1&nbsp;&nbsp;&nbsp;Install Boost.Build</a></h3>
-<p><a class="reference external" href="../../tools/build/index.html">Boost.Build</a> is a text-based system for developing, testing, and
+<div class="section" id="install-b2">
+<h3><a class="toc-backref" href="#id28">5.2.1&nbsp;&nbsp;&nbsp;Install B2</a></h3>
+<p><a class="reference external" href="../../tools/build/doc/html/index.html">B2</a> is a text-based system for developing, testing, and
 installing software. First, you'll need to build and
 install it. To do this:</p>
 <ol class="arabic simple">
 <li>Go to the directory <tt class="docutils literal">tools</tt><tt class="docutils literal">/</tt><tt class="docutils literal">build</tt><tt class="docutils literal">/</tt>.</li>
 <li>Run <tt class="docutils literal">bootstrap.sh</tt></li>
 <li>Run <tt class="docutils literal">b2 install <span class="pre">--prefix=</span></tt><em>PREFIX</em> where <em>PREFIX</em> is
-the directory where you want Boost.Build to be installed</li>
+the directory where you want B2 to be installed</li>
 <li>Add <em>PREFIX</em><tt class="docutils literal">/</tt><tt class="docutils literal">bin</tt> to your PATH environment variable.</li>
 </ol>
 </div>
 <div class="section" id="identify-your-toolset">
 <span id="toolset-name"></span><span id="toolset"></span><h3><a class="toc-backref" href="#id29">5.2.2&nbsp;&nbsp;&nbsp;Identify Your Toolset</a></h3>
 <p>First, find the toolset corresponding to your compiler in the
-following table (an up-to-date list is always available <a class="reference external" href="https://boostorg.github.io/build/manual/develop/index.html#bbv2.reference.tools">in the
-Boost.Build documentation</a>).</p>
+following table (an up-to-date list is always available <a class="reference external" href="../../tools/build/doc/html/index.html#bbv2.reference.tools">in the
+B2 documentation</a>).</p>
 <div class="admonition note">
 <p class="first admonition-title">Note</p>
 <p class="last">If you previously chose a toolset for the purposes of
-<a class="reference external" href="../../doc/html/bbv2/installation.html">building b2</a>, you should assume it won't work and instead
+<a class="reference external" href="../../tools/build/doc/html/index.html#bbv2.installation">building b2</a>, you should assume it won't work and instead
 choose newly from the table below.</p>
 </div>
 <table border="1" class="docutils">
@@ -356,7 +356,7 @@ Name</th>
 </tr>
 <tr><td><tt class="docutils literal">como</tt></td>
 <td>Comeau Computing</td>
-<td>Using this toolset may require <a class="reference external" href="../../tools/build/index.html">configuring</a> another
+<td>Using this toolset may require <a class="reference external" href="../../tools/build/doc/html/index.html">configuring</a> another
 toolset to act as its backend.</td>
 </tr>
 <tr><td><tt class="docutils literal">darwin</tt></td>
@@ -407,10 +407,10 @@ a hyphen, e.g. <tt class="docutils literal"><span class="pre">intel-9.0</span></
 </div>
 <div class="section" id="select-a-build-directory">
 <span id="id11"></span><span id="build-directory"></span><h3><a class="toc-backref" href="#id30">5.2.3&nbsp;&nbsp;&nbsp;Select a Build Directory</a></h3>
-<p><a class="reference external" href="../../tools/build/index.html">Boost.Build</a> will place all intermediate files it generates while
+<p><a class="reference external" href="../../tools/build/doc/html/index.html">B2</a> will place all intermediate files it generates while
 building into the <strong>build directory</strong>.  If your Boost root
 directory is writable, this step isn't strictly necessary: by
-default Boost.Build will create a <tt class="docutils literal">bin.v2/</tt> subdirectory for that
+default B2 will create a <tt class="docutils literal">bin.v2/</tt> subdirectory for that
 purpose in your current working directory.</p>
 </div>
 <div class="section" id="invoke-b2">
@@ -421,7 +421,7 @@ invoke <tt class="docutils literal">b2</tt> as follows:</p>
 b2 <strong>--build-dir=</strong><a class="reference internal" href="#id11"><em>build-directory</em></a> <strong>toolset=</strong><a class="reference internal" href="#toolset-name"><em>toolset-name</em></a> ``&nbsp;`` stage
 </pre>
 <p>For a complete description of these and other invocation options,
-please see the <a class="reference external" href="http://www.boost.org/build/doc/html/bbv2/overview/invocation.html">Boost.Build documentation</a>.</p>
+please see the <a class="reference external" href="../../tools/build/doc/html/index.html#bbv2.overview.invocation">B2 documentation</a>.</p>
 <p>For example, your session might look like this:</p>
 <pre class="literal-block">
 $ cd ~/<tt class="docutils literal">boost_1_76_0</tt>
@@ -455,7 +455,7 @@ be interested in:</p>
 </ul>
 <div class="admonition note">
 <p class="first admonition-title">Note</p>
-<p class="last">Boost.Build can produce a great deal of output, which can
+<p class="last">B2 can produce a great deal of output, which can
 make it easy to miss problems.  If you want to make sure
 everything is went well, you might redirect the output into a
 file by appending “<tt class="docutils literal">&gt;build.log <span class="pre">2&gt;&amp;1</span></tt>” to your command line.</p>
@@ -495,9 +495,9 @@ packages for libz and libbz2 if you need those features.  Other
 errors when building Boost libraries are cause for concern.</p>
 <p>If it seems like the build system can't find your compiler and/or
 linker, consider setting up a <tt class="docutils literal"><span class="pre">user-config.jam</span></tt> file as described
-<a class="reference external" href="http://www.boost.org/build/doc/html/bbv2/overview/configuration.html">here</a>.  If that isn't your problem or the <tt class="docutils literal"><span class="pre">user-config.jam</span></tt> file
+<a class="reference external" href="../../tools/build/doc/html/index.html#bbv2.overview.configuration">here</a>.  If that isn't your problem or the <tt class="docutils literal"><span class="pre">user-config.jam</span></tt> file
 doesn't work for you, please address questions about configuring Boost
-for your compiler to the <a class="reference external" href="http://www.boost.org/more/mailing_lists.htm#jamboost">Boost.Build mailing list</a>.</p>
+for your compiler to the <a class="reference external" href="http://www.boost.org/more/mailing_lists.htm#users">Boost Users' mailing list</a>.</p>
 <!-- Copyright David Abrahams 2006. Distributed under the Boost -->
 <!-- Software License, Version 1.0. (See accompanying -->
 <!-- file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt) -->
@@ -602,7 +602,7 @@ feature, a single letter is added to the tag:</p>
 <thead valign="bottom">
 <tr><th class="head">Key</th>
 <th class="head">Use this library when:</th>
-<th class="head">Boost.Build option</th>
+<th class="head">B2 option</th>
 </tr>
 </thead>
 <tbody valign="top">
@@ -649,7 +649,7 @@ ABI tag is ommitted.</p>
 <thead valign="bottom">
 <tr><th class="head">Key</th>
 <th class="head">Architecture</th>
-<th class="head">Boost.Build option</th>
+<th class="head">B2 option</th>
 </tr>
 </thead>
 <tbody valign="top">
@@ -691,7 +691,7 @@ ABI tag is ommitted.</p>
 <thead valign="bottom">
 <tr><th class="head">Key</th>
 <th class="head">Address model</th>
-<th class="head">Boost.Build option</th>
+<th class="head">B2 option</th>
 </tr>
 </thead>
 <tbody valign="top">
@@ -722,7 +722,7 @@ variants, a full version extension is added (e.g. &quot;.so.1.34&quot;) and
 a symbolic link to the library file, named without the trailing
 version number, will also be created.</dd>
 </dl>
-<!-- .. _Boost.Build toolset names: toolset-name_ -->
+<!-- .. _B2 toolset names: toolset-name_ -->
 <!-- Copyright David Abrahams 2006. Distributed under the Boost -->
 <!-- Software License, Version 1.0. (See accompanying -->
 <!-- file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt) -->
@@ -778,9 +778,8 @@ If you can't find what you need, or there's anything we can do to
 make this document clearer, please post it to the <a class="reference external" href="http://www.boost.org/more/mailing_lists.htm#users">Boost Users'
 mailing list</a>.</p>
 <ul class="simple">
-<li><a class="reference external" href="../../tools/build/index.html">Boost.Build reference manual</a></li>
+<li><a class="reference external" href="../../tools/build/doc/html/index.html">B2 reference manual</a></li>
 <li><a class="reference external" href="http://www.boost.org/more/mailing_lists.htm#users">Boost Users' mailing list</a></li>
-<li><a class="reference external" href="http://www.boost.org/more/mailing_lists.htm#jamboost">Boost.Build mailing list</a></li>
 <li><a class="reference external" href="../../libs/index.html">Index of all Boost library documentation</a></li>
 </ul>
 <div class="admonition admonition-onward">

--- a/getting_started/unix-variants.rst
+++ b/getting_started/unix-variants.rst
@@ -129,11 +129,11 @@ Or, Build Custom Binaries
 -------------------------
 
 If you're using a compiler other than your system's default, you'll
-need to use Boost.Build_ to create binaries.
+need to use B2_ to create binaries.
 
 You'll also
 use this method if you need a nonstandard build variant (see the
-`Boost.Build documentation`_ for more details).
+`B2 documentation`_ for more details).
 
 .. include:: detail/build-from-source-head.rst
 

--- a/getting_started/windows.html
+++ b/getting_started/windows.html
@@ -38,7 +38,7 @@ not supported—they may or may not work.</p>
 <li><a class="reference internal" href="#prepare-to-use-a-boost-library-binary" id="id35">5&nbsp;&nbsp;&nbsp;Prepare to Use a Boost Library Binary</a><ul class="auto-toc">
 <li><a class="reference internal" href="#simplified-build-from-source" id="id36">5.1&nbsp;&nbsp;&nbsp;Simplified Build From Source</a></li>
 <li><a class="reference internal" href="#or-build-binaries-from-source" id="id37">5.2&nbsp;&nbsp;&nbsp;Or, Build Binaries From Source</a><ul class="auto-toc">
-<li><a class="reference internal" href="#install-boost-build" id="id38">5.2.1&nbsp;&nbsp;&nbsp;Install Boost.Build</a></li>
+<li><a class="reference internal" href="#install-b2" id="id38">5.2.1&nbsp;&nbsp;&nbsp;Install B2</a></li>
 <li><a class="reference internal" href="#identify-your-toolset" id="id39">5.2.2&nbsp;&nbsp;&nbsp;Identify Your Toolset</a></li>
 <li><a class="reference internal" href="#select-a-build-directory" id="id40">5.2.3&nbsp;&nbsp;&nbsp;Select a Build Directory</a></li>
 <li><a class="reference internal" href="#invoke-b2" id="id41">5.2.4&nbsp;&nbsp;&nbsp;Invoke <tt class="docutils literal">b2</tt></a></li>
@@ -82,7 +82,7 @@ distribution.<a class="footnote-reference" href="#zip" id="id2"><sup>1</sup></a>
      <strong>array</strong><strong>\</strong>
                      <em>…more libraries…</em>
    <strong>status</strong><strong>\</strong> .........................<em>Boost-wide test suite</em>
-   <strong>tools</strong><strong>\</strong> ...........<em>Utilities, e.g. Boost.Build, quickbook, bcp</em>
+   <strong>tools</strong><strong>\</strong> ...........<em>Utilities, e.g. B2, quickbook, bcp</em>
    <strong>more</strong><strong>\</strong> ..........................<em>Policy documents, etc.</em>
    <strong>doc</strong><strong>\</strong> ...............<em>A subset of all Boost library docs</em>
 </pre>
@@ -354,41 +354,41 @@ the following commands:</p>
 bootstrap
 .\b2
 </pre>
-<p>The first command prepares the Boost.Build system for use. The second
-command invokes Boost.Build to build the separately-compiled Boost
-libraries. Please consult the <a class="reference external" href="http://www.boost.org/build/doc/html/bbv2/overview/invocation.html">Boost.Build documentation</a> for a list
+<p>The first command prepares the B2 system for use. The second
+command invokes B2 to build the separately-compiled Boost
+libraries. Please consult the <a class="reference external" href="../../tools/build/doc/html/index.html#bbv2.overview.invocation">B2 documentation</a> for a list
 of allowed options.</p>
 </div>
 <div class="section" id="or-build-binaries-from-source">
 <h2><a class="toc-backref" href="#id37">5.2&nbsp;&nbsp;&nbsp;Or, Build Binaries From Source</a></h2>
 <p>If you're using an earlier version of Visual C++, or a compiler
-from another vendor, you'll need to use <a class="reference external" href="../../tools/build/index.html">Boost.Build</a> to create your
+from another vendor, you'll need to use <a class="reference external" href="../../tools/build/doc/html/index.html">B2</a> to create your
 own binaries.</p>
 <!-- Copyright David Abrahams 2006. Distributed under the Boost -->
 <!-- Software License, Version 1.0. (See accompanying -->
 <!-- file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt) -->
-<div class="section" id="install-boost-build">
-<h3><a class="toc-backref" href="#id38">5.2.1&nbsp;&nbsp;&nbsp;Install Boost.Build</a></h3>
-<p><a class="reference external" href="../../tools/build/index.html">Boost.Build</a> is a text-based system for developing, testing, and
+<div class="section" id="install-b2">
+<h3><a class="toc-backref" href="#id38">5.2.1&nbsp;&nbsp;&nbsp;Install B2</a></h3>
+<p><a class="reference external" href="../../tools/build/doc/html/index.html">B2</a> is a text-based system for developing, testing, and
 installing software. First, you'll need to build and
 install it. To do this:</p>
 <ol class="arabic simple">
 <li>Go to the directory <tt class="docutils literal">tools</tt><tt class="docutils literal">\</tt><tt class="docutils literal">build</tt><tt class="docutils literal">\</tt>.</li>
 <li>Run <tt class="docutils literal">bootstrap.bat</tt></li>
 <li>Run <tt class="docutils literal">b2 install <span class="pre">--prefix=</span></tt><em>PREFIX</em> where <em>PREFIX</em> is
-the directory where you want Boost.Build to be installed</li>
+the directory where you want B2 to be installed</li>
 <li>Add <em>PREFIX</em><tt class="docutils literal">\</tt><tt class="docutils literal">bin</tt> to your PATH environment variable.</li>
 </ol>
 </div>
 <div class="section" id="identify-your-toolset">
 <span id="toolset-name"></span><span id="toolset"></span><h3><a class="toc-backref" href="#id39">5.2.2&nbsp;&nbsp;&nbsp;Identify Your Toolset</a></h3>
 <p>First, find the toolset corresponding to your compiler in the
-following table (an up-to-date list is always available <a class="reference external" href="https://boostorg.github.io/build/manual/develop/index.html#bbv2.reference.tools">in the
-Boost.Build documentation</a>).</p>
+following table (an up-to-date list is always available <a class="reference external" href="../../tools/build/doc/html/index.html#bbv2.reference.tools">in the
+B2 documentation</a>).</p>
 <div class="admonition note">
 <p class="first admonition-title">Note</p>
 <p class="last">If you previously chose a toolset for the purposes of
-<a class="reference external" href="../../doc/html/bbv2/installation.html">building b2</a>, you should assume it won't work and instead
+<a class="reference external" href="../../tools/build/doc/html/index.html#bbv2.installation">building b2</a>, you should assume it won't work and instead
 choose newly from the table below.</p>
 </div>
 <table border="1" class="docutils">
@@ -415,7 +415,7 @@ Name</th>
 </tr>
 <tr><td><tt class="docutils literal">como</tt></td>
 <td>Comeau Computing</td>
-<td>Using this toolset may require <a class="reference external" href="../../tools/build/index.html">configuring</a> another
+<td>Using this toolset may require <a class="reference external" href="../../tools/build/doc/html/index.html">configuring</a> another
 toolset to act as its backend.</td>
 </tr>
 <tr><td><tt class="docutils literal">darwin</tt></td>
@@ -469,10 +469,10 @@ detection code) or <a class="reference internal" href="#auto-linking">auto-linki
 </div>
 <div class="section" id="select-a-build-directory">
 <span id="id13"></span><span id="build-directory"></span><h3><a class="toc-backref" href="#id40">5.2.3&nbsp;&nbsp;&nbsp;Select a Build Directory</a></h3>
-<p><a class="reference external" href="../../tools/build/index.html">Boost.Build</a> will place all intermediate files it generates while
+<p><a class="reference external" href="../../tools/build/doc/html/index.html">B2</a> will place all intermediate files it generates while
 building into the <strong>build directory</strong>.  If your Boost root
 directory is writable, this step isn't strictly necessary: by
-default Boost.Build will create a <tt class="docutils literal">bin.v2/</tt> subdirectory for that
+default B2 will create a <tt class="docutils literal">bin.v2/</tt> subdirectory for that
 purpose in your current working directory.</p>
 </div>
 <div class="section" id="invoke-b2">
@@ -483,7 +483,7 @@ invoke <tt class="docutils literal">b2</tt> as follows:</p>
 b2 <strong>--build-dir=</strong><a class="reference internal" href="#id13"><em>build-directory</em></a> <strong>toolset=</strong><a class="reference internal" href="#toolset-name"><em>toolset-name</em></a> <strong>--build-type=complete</strong> stage
 </pre>
 <p>For a complete description of these and other invocation options,
-please see the <a class="reference external" href="http://www.boost.org/build/doc/html/bbv2/overview/invocation.html">Boost.Build documentation</a>.</p>
+please see the <a class="reference external" href="../../tools/build/doc/html/index.html#bbv2.overview.invocation">B2 documentation</a>.</p>
 <p>For example, your session might look like this:<a class="footnote-reference" href="#continuation" id="id15"><sup>3</sup></a></p>
 <pre class="literal-block">
 C:\WINDOWS&gt; cd <tt class="docutils literal"><span class="pre">C:\Program</span> Files\boost\</tt><tt class="docutils literal">boost_1_76_0</tt>
@@ -493,9 +493,9 @@ More? <strong>--build-type=complete</strong> <strong>msvc</strong> stage
 </pre>
 <p>Be sure to read <a class="reference internal" href="#continuation">this note</a> about the appearance of <tt class="docutils literal">^</tt>,
 <tt class="docutils literal">More?</tt> and quotation marks (<tt class="docutils literal">&quot;</tt>) in that line.</p>
-<p>The option “<strong>--build-type=complete</strong>” causes Boost.Build to build
+<p>The option “<strong>--build-type=complete</strong>” causes B2 to build
 all supported variants of the libraries.  For instructions on how to
-build only specific variants, please ask on the <a class="reference external" href="http://www.boost.org/more/mailing_lists.htm#jamboost">Boost.Build mailing
+build only specific variants, please ask on the <a class="reference external" href="http://www.boost.org/more/mailing_lists.htm#users">Boost Users' mailing
 list</a>.</p>
 <!-- Copyright David Abrahams 2006. Distributed under the Boost -->
 <!-- Software License, Version 1.0. (See accompanying -->
@@ -524,7 +524,7 @@ be interested in:</p>
 </ul>
 <div class="admonition note">
 <p class="first admonition-title">Note</p>
-<p class="last">Boost.Build can produce a great deal of output, which can
+<p class="last">B2 can produce a great deal of output, which can
 make it easy to miss problems.  If you want to make sure
 everything is went well, you might redirect the output into a
 file by appending “<tt class="docutils literal">&gt;build.log <span class="pre">2&gt;&amp;1</span></tt>” to your command line.</p>
@@ -564,9 +564,9 @@ packages for libz and libbz2 if you need those features.  Other
 errors when building Boost libraries are cause for concern.</p>
 <p>If it seems like the build system can't find your compiler and/or
 linker, consider setting up a <tt class="docutils literal"><span class="pre">user-config.jam</span></tt> file as described
-<a class="reference external" href="http://www.boost.org/build/doc/html/bbv2/overview/configuration.html">here</a>.  If that isn't your problem or the <tt class="docutils literal"><span class="pre">user-config.jam</span></tt> file
+<a class="reference external" href="../../tools/build/doc/html/index.html#bbv2.overview.configuration">here</a>.  If that isn't your problem or the <tt class="docutils literal"><span class="pre">user-config.jam</span></tt> file
 doesn't work for you, please address questions about configuring Boost
-for your compiler to the <a class="reference external" href="http://www.boost.org/more/mailing_lists.htm#jamboost">Boost.Build mailing list</a>.</p>
+for your compiler to the <a class="reference external" href="http://www.boost.org/more/mailing_lists.htm#users">Boost Users' mailing list</a>.</p>
 <span class="target" id="auto-linking"></span><!-- Copyright David Abrahams 2006. Distributed under the Boost -->
 <!-- Software License, Version 1.0. (See accompanying -->
 <!-- file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt) -->
@@ -690,7 +690,7 @@ feature, a single letter is added to the tag:</p>
 <thead valign="bottom">
 <tr><th class="head">Key</th>
 <th class="head">Use this library when:</th>
-<th class="head">Boost.Build option</th>
+<th class="head">B2 option</th>
 </tr>
 </thead>
 <tbody valign="top">
@@ -737,7 +737,7 @@ ABI tag is ommitted.</p>
 <thead valign="bottom">
 <tr><th class="head">Key</th>
 <th class="head">Architecture</th>
-<th class="head">Boost.Build option</th>
+<th class="head">B2 option</th>
 </tr>
 </thead>
 <tbody valign="top">
@@ -779,7 +779,7 @@ ABI tag is ommitted.</p>
 <thead valign="bottom">
 <tr><th class="head">Key</th>
 <th class="head">Address model</th>
-<th class="head">Boost.Build option</th>
+<th class="head">B2 option</th>
 </tr>
 </thead>
 <tbody valign="top">
@@ -810,7 +810,7 @@ variants, a full version extension is added (e.g. &quot;.so.1.34&quot;) and
 a symbolic link to the library file, named without the trailing
 version number, will also be created.</dd>
 </dl>
-<!-- .. _Boost.Build toolset names: toolset-name_ -->
+<!-- .. _B2 toolset names: toolset-name_ -->
 <!-- Copyright David Abrahams 2006. Distributed under the Boost -->
 <!-- Software License, Version 1.0. (See accompanying -->
 <!-- file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt) -->
@@ -848,9 +848,8 @@ If you can't find what you need, or there's anything we can do to
 make this document clearer, please post it to the <a class="reference external" href="http://www.boost.org/more/mailing_lists.htm#users">Boost Users'
 mailing list</a>.</p>
 <ul class="simple">
-<li><a class="reference external" href="../../tools/build/index.html">Boost.Build reference manual</a></li>
+<li><a class="reference external" href="../../tools/build/doc/html/index.html">B2 reference manual</a></li>
 <li><a class="reference external" href="http://www.boost.org/more/mailing_lists.htm#users">Boost Users' mailing list</a></li>
-<li><a class="reference external" href="http://www.boost.org/more/mailing_lists.htm#jamboost">Boost.Build mailing list</a></li>
 <li><a class="reference external" href="../../libs/index.html">Index of all Boost library documentation</a></li>
 </ul>
 <div class="admonition admonition-onward">

--- a/getting_started/windows.rst
+++ b/getting_started/windows.rst
@@ -178,18 +178,18 @@ the following commands::
   bootstrap
   .\b2
 
-The first command prepares the Boost.Build system for use. The second
-command invokes Boost.Build to build the separately-compiled Boost
-libraries. Please consult the `Boost.Build documentation`__ for a list
+The first command prepares the B2 system for use. The second
+command invokes B2 to build the separately-compiled Boost
+libraries. Please consult the `B2 documentation`__ for a list
 of allowed options.
 
-__ http://www.boost.org/build/doc/html/bbv2/overview/invocation.html
+__ ../../tools/build/doc/html/index.html#bbv2.overview.invocation
 
 Or, Build Binaries From Source
 ------------------------------
 
 If you're using an earlier version of Visual C++, or a compiler
-from another vendor, you'll need to use Boost.Build_ to create your
+from another vendor, you'll need to use B2_ to create your
 own binaries.
 
 .. include:: detail/build-from-source-head.rst
@@ -206,9 +206,9 @@ For example, your session might look like this: [#continuation]_
 Be sure to read `this note`__ about the appearance of ``^``,
 ``More?`` and quotation marks (``"``) in that line.
 
-The option “\ **--build-type=complete**\ ” causes Boost.Build to build
+The option “\ **--build-type=complete**\ ” causes B2 to build
 all supported variants of the libraries.  For instructions on how to
-build only specific variants, please ask on the `Boost.Build mailing
+build only specific variants, please ask on the `Boost Users' mailing
 list`_.
 
 __ continuation_


### PR DESCRIPTION
This updates the getting started docs to refer to the canonical B2 name.
Also updates all the links to B2 documentation to point to the local
tools/build sourced location. Hence making those links work in both
off-line and on-line (versioned) versions of this documentation.